### PR TITLE
Add incognito/private window option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 * Add copy links to clipboard (#28)
   * Copy button in popup writes checked URLs (newline-separated) to clipboard
   * Context menu item and keyboard shortcut (`osl_copy`) for copy without opening the popup
+* Add incognito/private window option (#29)
+  * "Incognito/private" checkbox in popup; greyed out with a note if Chrome hasn't granted incognito access
+  * When opened from an incognito window, the checkbox is pre-checked so new windows inherit privacy by default; user can uncheck to escape to a regular window
+  * Context menu and keyboard commands respect the saved incognito setting
+  * If already in an incognito window, "open in current window" stays there rather than creating a new one
 # Version 1.8.4
 * Fix open in new window from menu or command
 # Version 1.8.3

--- a/html/popup.html
+++ b/html/popup.html
@@ -37,6 +37,11 @@
             <input id="new-window-checkbox" type="checkbox" checked>
             <label for="new-window-checkbox">New window</label>
           </div>
+          <div id="target-incognito-ui">
+            <input id="incognito-checkbox" type="checkbox">
+            <label for="incognito-checkbox">Incognito/private</label>
+            <span class="option-note" id="incognito-note" style="display:none">(enable in extension settings)</span>
+          </div>
           <div id="tab-group-ui">
             <label for="tab-group-name">Tab group:</label>
             <input id="tab-group-name" type="text" placeholder="Choose existing or enter new name" list="tab-group-list">

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -67,9 +67,12 @@ const processOSLRequest = async (osl_request_id: OSLRequestID, tab: browser.Tabs
     discard: settings.auto_discard,
     deduplicate: settings.deduplicate,
     focus: settings.focus,
+    incognito: settings.incognito,
   };
   if (osl_request_id === OSLRequestID.CurrentWindow) {
-    options.windowId = browser.windows.WINDOW_ID_CURRENT;
+    options.windowId = (settings.incognito && !tab.incognito)
+      ? browser.windows.WINDOW_ID_NONE
+      : browser.windows.WINDOW_ID_CURRENT;
   } else if (osl_request_id === OSLRequestID.NewWindow) {
     options.windowId = browser.windows.WINDOW_ID_NONE;
   } else if (osl_request_id === OSLRequestID.NewTabGroup) {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -67,7 +67,7 @@ const processOSLRequest = async (osl_request_id: OSLRequestID, tab: browser.Tabs
     discard: settings.auto_discard,
     deduplicate: settings.deduplicate,
     focus: settings.focus,
-    incognito: settings.incognito,
+    incognito: settings.incognito || (tab.incognito ?? false),
   };
   if (osl_request_id === OSLRequestID.CurrentWindow) {
     options.windowId = (settings.incognito && !tab.incognito)

--- a/src/common/extract-links.ts
+++ b/src/common/extract-links.ts
@@ -81,6 +81,7 @@ export interface MakeTabOptions {
   discard?: boolean,
   deduplicate?: boolean,
   focus?: boolean,
+  incognito?: boolean,
   position?: 'left' | 'right',
   display?: any
   isPopup?: boolean,
@@ -183,6 +184,7 @@ const createWindow = async (links: string[], options: MakeTabOptions): Promise<n
   const windowCreateOptions: browser.Windows.CreateCreateDataType = {
     url: links,
     focused: options.focus,
+    incognito: options.incognito,
   };
   if (workArea) {
     if (options.position === 'left') {

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -5,6 +5,7 @@ export enum SettingID {
   AutoDiscard = 'auto_discard',
   Deduplicate = 'deduplicate',
   Focus = 'focus',
+  Incognito = 'incognito',
   PopupHideDuplicates = 'popup_hide_duplicates',
   PopupMatchUrls = 'popup_match_urls',
 }
@@ -27,13 +28,14 @@ export interface Settings {
   auto_discard: boolean,
   deduplicate: boolean,
   focus: boolean,
+  incognito: boolean,
   popup_hide_duplicates: boolean,
   popup_match_urls: boolean,
 }
 
 export function setBoolean(settings: Settings, id: keyof Settings, value: boolean) {
   if (id == SettingID.UseNewWindow || id == SettingID.AutoDiscard ||
-    id == SettingID.Deduplicate || id == SettingID.Focus ||
+    id == SettingID.Deduplicate || id == SettingID.Focus || id == SettingID.Incognito ||
     id == SettingID.PopupHideDuplicates || id == SettingID.PopupMatchUrls) {
     settings[id] = value
   }
@@ -75,6 +77,12 @@ export const settingSpecs: SettingSpec[] = [
     description: 'Give focus to opened tab/window',
     input_type: InputType.Checkbox,
     default_: true,
+  },
+  {
+    name: SettingID.Incognito,
+    description: 'Open links in incognito/private window',
+    input_type: InputType.Checkbox,
+    default_: false,
   },
   {
     name: SettingID.PopupHideDuplicates,

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -424,9 +424,15 @@ const setupIncognito = async () => {
       cb.disabled = true;
       cb.checked = false;
       (document.getElementById('incognito-note') as HTMLElement).style.display = '';
+      return;
     }
   } catch {
     // Firefox: always allowed, API may behave differently
+  }
+  // Pre-check when already in an incognito window so new windows inherit privacy.
+  // The user can uncheck to explicitly open in a regular window.
+  if (currentWindowIsIncognito) {
+    cb.checked = true;
   }
 }
 

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -29,6 +29,7 @@ const applySettings = async () => {
     [SettingID.AutoDiscard, 'discard-tab-checkbox'],
     [SettingID.Deduplicate, 'deduplicate-links-checkbox'],
     [SettingID.Focus, 'focus-checkbox'],
+    [SettingID.Incognito, 'incognito-checkbox'],
     [SettingID.PopupHideDuplicates, 'hide-duplicates-checkbox'],
     [SettingID.PopupMatchUrls, 'filter-urls-checkbox'],
   ];
@@ -44,12 +45,13 @@ const applySettings = async () => {
 }
 
 const URL_PARAMS = new URLSearchParams(window.location.search);
+let currentWindowIsIncognito = false;
 
-const getCurrentTabId = async () => {
+const getCurrentTabId = async (): Promise<{ id: number | undefined, incognito: boolean }> => {
   const tabId = URL_PARAMS.get("tab");
   if (tabId != null) {
     console.log('getCurrentTabId: using query tabId:', tabId)
-    return parseInt(tabId);
+    return { id: parseInt(tabId), incognito: false };
   }
   try {
     const [tab] = await browser.tabs.query({
@@ -57,7 +59,7 @@ const getCurrentTabId = async () => {
       currentWindow: true,
     })
     console.log('getCurrentTabId: Getting current tab:', tab)
-    return tab.id
+    return { id: tab.id, incognito: tab.incognito ?? false };
   } catch (e: any) {
     if (e instanceof TypeError) {
       const [tab] = await browser.tabs.query({
@@ -65,7 +67,7 @@ const getCurrentTabId = async () => {
         currentWindow: true,
       })
       console.log('getCurrentTabId: Getting current tab:', tab)
-      return tab.id
+      return { id: tab.id, incognito: tab.incognito ?? false };
     }
     throw e;
   }
@@ -102,9 +104,11 @@ const openLinks = async (event: Event) => {
   console.log('openLinks: Form:', form)
   const links = getCheckedUrls();
   console.log('openLinks: Links:', links)
+  const incognito = getInput('incognito-checkbox').checked;
   const options: {[key: string]: any} = {
     discard: getInput('discard-tab-checkbox').checked,
     deduplicate: getInput('deduplicate-links-checkbox').checked,
+    incognito,
     isPopup: true,
   }
   const displayOption = (document.getElementById('display') as HTMLInputElement | undefined)?.value;
@@ -135,7 +139,7 @@ const openLinks = async (event: Event) => {
       throw e
     }
   } else {
-    options.windowId = getInput('new-window-checkbox').checked
+    options.windowId = (getInput('new-window-checkbox').checked || (incognito && !currentWindowIsIncognito))
       ? browser.windows.WINDOW_ID_NONE
       : browser.windows.WINDOW_ID_CURRENT;
     options.tabGroupName = getInput('tab-group-name').value || undefined;
@@ -412,6 +416,20 @@ const setupDisplay = () => {
   }
 }
 
+const setupIncognito = async () => {
+  const cb = getInput('incognito-checkbox');
+  try {
+    const allowed = await browser.extension.isAllowedIncognitoAccess();
+    if (!allowed) {
+      cb.disabled = true;
+      cb.checked = false;
+      (document.getElementById('incognito-note') as HTMLElement).style.display = '';
+    }
+  } catch {
+    // Firefox: always allowed, API may behave differently
+  }
+}
+
 const setupHamburger = () => {
   const hamburger = document.getElementById('hamburger')!;
   const hamburgerCaption = document.getElementById('hamburger-caption')!
@@ -438,7 +456,8 @@ const main = async () => {
 
     err.msg = 'Unable to get tab ID'
     err.sub = ''
-    const tabId = await getCurrentTabId();
+    const { id: tabId, incognito: tabIncognito } = await getCurrentTabId();
+    currentWindowIsIncognito = tabIncognito;
     if (tabId == undefined) {
       throw Error('Failed to get current tab')
     }
@@ -462,6 +481,7 @@ const main = async () => {
     setupCopyButton();
     setupSxS();
     setupDisplay();
+    await setupIncognito();
     setupHamburger();
     await setupTabGroupNameInput();
     renderForm(links, labels, session);

--- a/test/popup.test.ts
+++ b/test/popup.test.ts
@@ -31,6 +31,8 @@ const POPUP_HTML = `
       </fieldset>
       <fieldset>
         <input id="new-window-checkbox" type="checkbox" checked>
+        <input id="incognito-checkbox" type="checkbox">
+        <span id="incognito-note" style="display:none"></span>
         <div id="tab-group-ui">
           <input id="tab-group-name" type="text">
           <datalist id="tab-group-list"></datalist>
@@ -290,6 +292,185 @@ describe('filterRows', () => {
     for (const row of document.querySelectorAll('div.row')) {
       expect(row.classList.contains('invisible')).toBe(false);
     }
+  });
+});
+
+// Shared beforeEach body for setupIncognito describe blocks — only the
+// isAllowedIncognitoAccess mock differs between them.
+const makeIncognitoBeforeEach = (extensionMock: object) => async () => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  document.body.innerHTML = POPUP_HTML;
+  document.head.innerHTML = '';
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    writable: true,
+    configurable: true,
+  });
+  setupBrowserMocks(['http://a.example/'], ['A']);
+  (browser as any).extension = extensionMock;
+  await import('../src/popup/index.ts');
+};
+
+describe('setupIncognito — access granted', () => {
+  beforeEach(makeIncognitoBeforeEach({
+    isAllowedIncognitoAccess: vi.fn().mockResolvedValue(true),
+  }));
+
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  test('incognito checkbox is enabled', () => {
+    expect((document.getElementById('incognito-checkbox') as HTMLInputElement).disabled).toBe(false);
+  });
+
+  test('incognito note stays hidden', () => {
+    expect((document.getElementById('incognito-note') as HTMLElement).style.display).toBe('none');
+  });
+});
+
+describe('setupIncognito — access denied', () => {
+  beforeEach(makeIncognitoBeforeEach({
+    isAllowedIncognitoAccess: vi.fn().mockResolvedValue(false),
+  }));
+
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  test('incognito checkbox is disabled', () => {
+    expect((document.getElementById('incognito-checkbox') as HTMLInputElement).disabled).toBe(true);
+  });
+
+  test('incognito checkbox is unchecked when disabled', () => {
+    expect((document.getElementById('incognito-checkbox') as HTMLInputElement).checked).toBe(false);
+  });
+
+  test('incognito note is visible', () => {
+    expect((document.getElementById('incognito-note') as HTMLElement).style.display).not.toBe('none');
+  });
+});
+
+describe('setupIncognito — API unavailable (Firefox / undefined)', () => {
+  // browser.extension is not set — accessing .isAllowedIncognitoAccess() throws a
+  // TypeError, which setupIncognito catches and treats as "always allowed".
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    document.body.innerHTML = POPUP_HTML;
+    document.head.innerHTML = '';
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    });
+    setupBrowserMocks(['http://a.example/'], ['A']);
+    delete (browser as any).extension;
+    await import('../src/popup/index.ts');
+  });
+
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  test('incognito checkbox remains enabled', () => {
+    expect((document.getElementById('incognito-checkbox') as HTMLInputElement).disabled).toBe(false);
+  });
+});
+
+describe('openLinks — incognito mode', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    document.body.innerHTML = POPUP_HTML;
+    document.head.innerHTML = '';
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    });
+    vi.spyOn(window, 'close').mockImplementation(() => {});
+    setupBrowserMocks(['http://a.example/', 'http://b.example/'], ['A', 'B']);
+    browser.windows.create.mockResolvedValue({ id: 100, tabs: [{ id: 1 }, { id: 2 }] });
+    browser.tabs.create.mockResolvedValue({ id: 3 });
+    browser.tabs.update.mockResolvedValue({});
+    // access granted so the checkbox isn't disabled by setupIncognito
+    (browser as any).extension = { isAllowedIncognitoAccess: vi.fn().mockResolvedValue(true) };
+    await import('../src/popup/index.ts');
+    for (const cb of document.querySelectorAll<HTMLInputElement>('input[name="select-links"]')) {
+      cb.checked = true;
+    }
+    (document.getElementById('incognito-checkbox') as HTMLInputElement).checked = true;
+  });
+
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  test('windows.create is called with incognito: true', async () => {
+    document.getElementById('open-button')!.click();
+    await flushPromises();
+    expect(browser.windows.create).toHaveBeenCalledWith(
+      expect.objectContaining({ incognito: true }),
+    );
+  });
+
+  test('forces a new window even when the new-window checkbox is unchecked', async () => {
+    (document.getElementById('new-window-checkbox') as HTMLInputElement).checked = false;
+    document.getElementById('open-button')!.click();
+    await flushPromises();
+    expect(browser.windows.create).toHaveBeenCalled();
+    expect(browser.tabs.create).not.toHaveBeenCalled();
+  });
+
+  test('SxS mode passes incognito: true to both window creates', async () => {
+    (document.getElementById('sxs-checkbox') as HTMLInputElement).checked = true;
+    document.getElementById('open-button')!.click();
+    await flushPromises();
+    expect(browser.windows.create).toHaveBeenCalledTimes(2);
+    for (const [args] of browser.windows.create.mock.calls) {
+      expect(args).toMatchObject({ incognito: true });
+    }
+  });
+});
+
+describe('openLinks — incognito already in incognito window', () => {
+  // When the current window is already incognito, enabling the incognito option
+  // should open in the current window rather than forcing a new one.
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    document.body.innerHTML = POPUP_HTML;
+    document.head.innerHTML = '';
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    });
+    vi.spyOn(window, 'close').mockImplementation(() => {});
+    setupBrowserMocks(['http://a.example/', 'http://b.example/'], ['A', 'B']);
+    // Simulate that the current tab belongs to an incognito window.
+    browser.tabs.query.mockResolvedValue([{ id: 42, incognito: true }]);
+    browser.windows.create.mockResolvedValue({ id: 100, tabs: [{ id: 1 }, { id: 2 }] });
+    browser.tabs.create.mockResolvedValue({ id: 3 });
+    browser.tabs.update.mockResolvedValue({});
+    (browser as any).extension = { isAllowedIncognitoAccess: vi.fn().mockResolvedValue(true) };
+    await import('../src/popup/index.ts');
+    for (const cb of document.querySelectorAll<HTMLInputElement>('input[name="select-links"]')) {
+      cb.checked = true;
+    }
+    (document.getElementById('new-window-checkbox') as HTMLInputElement).checked = false;
+    (document.getElementById('incognito-checkbox') as HTMLInputElement).checked = true;
+  });
+
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  test('opens in the current window, not a new one', async () => {
+    document.getElementById('open-button')!.click();
+    await flushPromises();
+    expect(browser.windows.create).not.toHaveBeenCalled();
+    expect(browser.tabs.create).toHaveBeenCalled();
+  });
+
+  test('still passes incognito: true to tab options', async () => {
+    document.getElementById('open-button')!.click();
+    await flushPromises();
+    // tabs.create is used for current-window mode; incognito is on the window not the tab,
+    // so we just verify windows.create was NOT called (we're staying in the current window).
+    expect(browser.windows.create).not.toHaveBeenCalled();
   });
 });
 

--- a/test/popup.test.ts
+++ b/test/popup.test.ts
@@ -326,6 +326,35 @@ describe('setupIncognito — access granted', () => {
   test('incognito note stays hidden', () => {
     expect((document.getElementById('incognito-note') as HTMLElement).style.display).toBe('none');
   });
+
+  test('incognito checkbox is not pre-checked when current window is regular', () => {
+    // setupBrowserMocks returns incognito: undefined (falsy) on the tab
+    expect((document.getElementById('incognito-checkbox') as HTMLInputElement).checked).toBe(false);
+  });
+});
+
+describe('setupIncognito — access granted, current window is incognito', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    document.body.innerHTML = POPUP_HTML;
+    document.head.innerHTML = '';
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    });
+    setupBrowserMocks(['http://a.example/'], ['A']);
+    browser.tabs.query.mockResolvedValue([{ id: 42, incognito: true }]);
+    (browser as any).extension = { isAllowedIncognitoAccess: vi.fn().mockResolvedValue(true) };
+    await import('../src/popup/index.ts');
+  });
+
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  test('incognito checkbox is pre-checked to inherit window privacy', () => {
+    expect((document.getElementById('incognito-checkbox') as HTMLInputElement).checked).toBe(true);
+  });
 });
 
 describe('setupIncognito — access denied', () => {
@@ -471,6 +500,16 @@ describe('openLinks — incognito already in incognito window', () => {
     // tabs.create is used for current-window mode; incognito is on the window not the tab,
     // so we just verify windows.create was NOT called (we're staying in the current window).
     expect(browser.windows.create).not.toHaveBeenCalled();
+  });
+
+  test('explicitly unchecking incognito then choosing new window opens a regular window', async () => {
+    (document.getElementById('incognito-checkbox') as HTMLInputElement).checked = false;
+    (document.getElementById('new-window-checkbox') as HTMLInputElement).checked = true;
+    document.getElementById('open-button')!.click();
+    await flushPromises();
+    expect(browser.windows.create).toHaveBeenCalledWith(
+      expect.objectContaining({ incognito: false }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #26

- Add `incognito` boolean to `Settings` and the options page (auto-rendered from `settingSpecs`)
- Add "Incognito/private" checkbox to the popup; greyed out with a note if Chrome hasn't granted incognito access (`browser.extension.isAllowedIncognitoAccess()`)
- Pass `incognito: true` to `browser.windows.create()` via the new `MakeTabOptions.incognito` field
- If the current window is already incognito, skip creating a new window and open tabs there instead (detected via `tab.incognito` in both popup and background)
- Background service worker reads the saved setting and applies it to all open commands; `CurrentWindow` mode upgrades to a new incognito window only when the current window is not already private

## Test plan

- [x] Popup checkbox visible and functional in Chrome (with incognito access granted)
- [x] Checkbox disabled with note in Chrome when extension not allowed in incognito
- [x] Popup checkbox visible and functional in Firefox (with incognito access granted)
- [x] Checkbox disabled with note in Firefox when extension not allowed in incognito
- [x] Links open in new incognito window when current window is normal even if current window requested
- [x] Links open in current window when already in incognito if current window requested
- [x] Context menu / keyboard command respects saved incognito setting
- [x] Context menu / keyboard command prefers tab incognito setting
- [x] All 107 unit tests pass (`bun run test`)
- [x] No lint errors (`bun run lint`)