### PR TITLE
Show [empty] for empty link labels, not just null/undefined

### DIFF
--- a/src/contentScript/extractor.ts
+++ b/src/contentScript/extractor.ts
@@ -26,7 +26,7 @@ export class SelectionLinkExtractor {
 	if (url.protocol.startsWith('http')) {
 	  this.links.push(url.href);
 	  if (this.debug) { console.log('anchor:', anchor) };
-	  this.labels.push(anchor.textContent?.trim() ?? '[empty]');
+	  this.labels.push(anchor.textContent?.trim() || '[empty]');
 	  this.anchors.push(anchor);
 	}
       } catch {

--- a/test/contentScript.test.ts
+++ b/test/contentScript.test.ts
@@ -254,6 +254,19 @@ test('processAnchorAncestor: invalid URL in ancestor anchor is caught', () => {
   expect(extractor.links).toHaveLength(0);
 });
 
+test('processFragment: empty label falls back to [empty]', () => {
+  window.location.href = 'http://localhost/';
+  const extractor = new SelectionLinkExtractor();
+  const fragment = document.createDocumentFragment();
+  const a = document.createElement('a');
+  a.href = 'http://x/';
+  a.innerHTML = '<img src="something.jpg">';
+  fragment.appendChild(a);
+  extractor.processFragment(fragment);
+  expect(extractor.links).toEqual(['http://x/']);
+  expect(extractor.labels).toEqual(['[empty]']);
+});
+
 test('Anchor ancestor is found', () => {
   document.body.innerHTML = `<a href="http://localhost/a">
 a<div id="child">b</div>


### PR DESCRIPTION
## Summary
- Fixes #31
- `anchor.textContent?.trim() ?? '[empty]'` only falls back on `null`/`undefined`, so a link whose anchor has no text (e.g. an image-only link like `<a href="..."><img src="..."></a>`) got an empty-string label instead of `[empty]`
- Switched to `||` so empty strings fall back to `[empty]` too (non-empty strings, including `"0"`, are untouched since they're truthy)

## Test plan
- [x] Added `test/contentScript.test.ts` case: `<a href="http://x/"><img src="something.jpg"></a>` → label `['[empty]']`
- [x] `bunx vitest run test/contentScript.test.ts` — 16/16 passing