### PR TITLE
Traverse open shadow roots when extracting links

### DIFF
--- a/src/contentScript/extractor.ts
+++ b/src/contentScript/extractor.ts
@@ -20,7 +20,7 @@ export class SelectionLinkExtractor {
   processFragment(documentFragment: DocumentFragment) {
     const base = document.head.querySelector('base');
     const baseURL = base ? base.href : window.location.href;
-    for (const anchor of documentFragment.querySelectorAll('a[href]') as NodeListOf<HTMLAnchorElement>) {
+    for (const anchor of this.collectAnchors(documentFragment)) {
       try {
 	const url = new URL(anchor.href, baseURL);
 	if (url.protocol.startsWith('http')) {
@@ -34,6 +34,33 @@ export class SelectionLinkExtractor {
       }
     }
     if (this.debug) { console.log('Done processing fragment') }
+  }
+
+  // Cloning a selection (Range.cloneContents) never carries open shadow
+  // roots along with their hosts, so this recursion only bears fruit when
+  // called on a *live* shadow root (see processShadowHosts below).
+  private collectAnchors(root: DocumentFragment | ShadowRoot): HTMLAnchorElement[] {
+    const anchors = Array.from(root.querySelectorAll('a[href]')) as HTMLAnchorElement[];
+    for (const element of root.querySelectorAll('*')) {
+      if (element.shadowRoot) {
+	anchors.push(...this.collectAnchors(element.shadowRoot));
+      }
+    }
+    return anchors;
+  }
+
+  // Shadow trees aren't part of the light DOM that Range.cloneContents()
+  // clones, so find shadow hosts intersecting the live selection directly
+  // and process their (live) shadow roots for links.
+  processShadowHosts(range: Range) {
+    const ancestor = range.commonAncestorContainer;
+    const container = ancestor instanceof Element ? ancestor : ancestor.parentElement;
+    if (!container) return;
+    for (const element of container.querySelectorAll('*')) {
+      if (element.shadowRoot && range.intersectsNode(element)) {
+	this.processFragment(element.shadowRoot);
+      }
+    }
   }
 
   processAnchorAncestor(selection: Selection) {
@@ -72,7 +99,9 @@ export class SelectionLinkExtractor {
     }
     for (let rangeIdx = 0; rangeIdx < selection.rangeCount; ++rangeIdx) {
       if (this.debug) { console.log('processing range', rangeIdx + 1) }
-      this.processFragment(selection.getRangeAt(rangeIdx).cloneContents());
+      const range = selection.getRangeAt(rangeIdx);
+      this.processFragment(range.cloneContents());
+      this.processShadowHosts(range);
     }
     // Special case if the selection is completely contained inside an anchor.
     if (this.links.length == 0 && selection.rangeCount > 0) {

--- a/test/contentScript.test.ts
+++ b/test/contentScript.test.ts
@@ -267,6 +267,118 @@ test('processFragment: empty label falls back to [empty]', () => {
   expect(extractor.labels).toEqual(['[empty]']);
 });
 
+test('processSelection: traverses open shadow root for links', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = '<p>text</p><div id="host"></div>';
+  const host = document.getElementById('host')!;
+  const shadow = host.attachShadow({ mode: 'open' });
+  shadow.innerHTML = '<a href="http://localhost/shadow">Shadow link</a>';
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  selection.selectAllChildren(document.body);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual(['http://localhost/shadow']);
+  expect(extractor.labels).toEqual(['Shadow link']);
+});
+
+test('processSelection: traverses nested open shadow roots for links', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = '<div id="host"></div>';
+  const host = document.getElementById('host')!;
+  const shadow = host.attachShadow({ mode: 'open' });
+  shadow.innerHTML = '<div id="inner-host"></div>';
+  const innerHost = shadow.getElementById('inner-host')!;
+  const innerShadow = innerHost.attachShadow({ mode: 'open' });
+  innerShadow.innerHTML = '<a href="http://localhost/nested">Nested link</a>';
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  selection.selectAllChildren(document.body);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual(['http://localhost/nested']);
+  expect(extractor.labels).toEqual(['Nested link']);
+});
+
+test('processSelection: mix of light DOM and shadow DOM links', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = `
+    <a href="http://localhost/before">Before</a>
+    <div id="host"></div>
+    <a href="http://localhost/after">After</a>
+  `;
+  const host = document.getElementById('host')!;
+  const shadow = host.attachShadow({ mode: 'open' });
+  shadow.innerHTML = '<a href="http://localhost/shadow">Shadow link</a>';
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  selection.selectAllChildren(document.body);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual([
+    'http://localhost/before',
+    'http://localhost/after',
+    'http://localhost/shadow',
+  ]);
+  expect(extractor.labels).toEqual([
+    'Before',
+    'After',
+    'Shadow link',
+  ]);
+});
+
+test('processSelection: multiple shadow hosts alongside light DOM links', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = `
+    <a href="http://localhost/a">A</a>
+    <div id="host1"></div>
+    <a href="http://localhost/b">B</a>
+    <div id="host2"></div>
+  `;
+  const host1 = document.getElementById('host1')!;
+  host1.attachShadow({ mode: 'open' }).innerHTML =
+    '<a href="http://localhost/shadow1">Shadow 1</a>';
+  const host2 = document.getElementById('host2')!;
+  host2.attachShadow({ mode: 'open' }).innerHTML =
+    '<a href="http://localhost/shadow2">Shadow 2</a>';
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  selection.selectAllChildren(document.body);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual([
+    'http://localhost/a',
+    'http://localhost/b',
+    'http://localhost/shadow1',
+    'http://localhost/shadow2',
+  ]);
+  expect(extractor.labels).toEqual([
+    'A',
+    'B',
+    'Shadow 1',
+    'Shadow 2',
+  ]);
+});
+
+test('processSelection: closed shadow root is left untouched', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = '<div id="host"></div>';
+  const host = document.getElementById('host')!;
+  const shadow = host.attachShadow({ mode: 'closed' });
+  shadow.innerHTML = '<a href="http://localhost/closed">Closed link</a>';
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  selection.selectAllChildren(document.body);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toHaveLength(0);
+});
+
 test('Anchor ancestor is found', () => {
   document.body.innerHTML = `<a href="http://localhost/a">
 a<div id="child">b</div>


### PR DESCRIPTION
## Summary
- Implements #32
- `processFragment`'s `documentFragment.querySelectorAll('a[href]')` never sees into shadow DOM, and `Range.cloneContents()` doesn't carry shadow roots over to the clone either, so links rendered inside open shadow roots (web components, some CMS themes) were silently skipped
- Added `processShadowHosts(range)`, called from `processSelection` alongside the existing `cloneContents()` pass: it walks the *live* selection range for shadow hosts (`element.shadowRoot`) that intersect the range (`Range.intersectsNode`) and feeds each host's live shadow root back through `processFragment`
- `processFragment` now collects anchors via a new `collectAnchors()` helper that recurses into any further-nested open shadow roots it finds, so nested web components are handled too
- Closed shadow roots are left untouched — not a bug, per spec (matches the issue's caveat)

## Test plan
- [x] Single open shadow host with a link inside a selection
- [x] Nested open shadow roots (shadow root containing another shadow host)
- [x] Closed shadow root is *not* traversed
- [x] Mix of light DOM and shadow DOM links in one selection, order preserved
- [x] Multiple independent shadow hosts alongside light DOM links
- [x] `bunx vitest run` — 111/111 passing
- [x] `bunx tsc --noEmit` — clean