### PR TITLE
Recover links when a selection lies entirely inside an open shadow root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Version 1.8.6
+* Show `[empty]` for links with no text, not just missing text (#33)
+* Traverse open shadow roots when extracting links (#34)
+  * Fixes links not being found on sites that render content in web
+    components, e.g. Internet Archive
+* Fix links not found when a selection lies entirely inside an open shadow
+  root (#35)
+  * Browsers collapse such a selection's `Range` to a zero-width point;
+    recover the real boundary points via `Selection.getComposedRanges()`
+    where supported (Chrome 127+, Firefox 142+)
+  * Fixes #30
 # Version 1.8.5
 * Add copy links to clipboard (#28)
   * Copy button in popup writes checked URLs (newline-separated) to clipboard

--- a/src/contentScript/extractor.ts
+++ b/src/contentScript/extractor.ts
@@ -54,13 +54,95 @@ export class SelectionLinkExtractor {
   // and process their (live) shadow roots for links.
   processShadowHosts(range: Range) {
     const ancestor = range.commonAncestorContainer;
-    const container = ancestor instanceof Element ? ancestor : ancestor.parentElement;
+    // A range built directly inside a shadow root (see processComposedShadowSelection)
+    // can have that ShadowRoot itself as commonAncestorContainer. Check nodeType rather
+    // than instanceof Element/DocumentFragment: instanceof can misfire across realms
+    // (e.g. cross-iframe nodes), which happy-dom's test environment hits for ShadowRoot.
+    const container: ParentNode | null =
+      ancestor.nodeType === Node.ELEMENT_NODE || ancestor.nodeType === Node.DOCUMENT_FRAGMENT_NODE
+	? (ancestor as unknown as ParentNode)
+	: ancestor.parentElement;
     if (!container) return;
     for (const element of container.querySelectorAll('*')) {
       if (element.shadowRoot && range.intersectsNode(element)) {
 	this.processFragment(element.shadowRoot);
       }
     }
+  }
+
+  // When a selection lies entirely inside an open shadow root, Selection.getRangeAt()
+  // retargets both boundary points to the same spot next to the shadow host, collapsing
+  // the range to zero width (see https://github.com/nkrishnaswami/open-selected-links/issues/32).
+  // Selection.getComposedRanges() (unsupported in Firefox as of this writing) can resolve
+  // the true boundary points inside shadow trees we tell it about, letting us rebuild a
+  // real, non-collapsed Range scoped to whichever root actually contains the selection.
+  processComposedShadowSelection(selection: Selection) {
+    if (typeof selection.getComposedRanges !== 'function') return;
+    const shadowRoots = this.findAllShadowRoots(document.body);
+    if (shadowRoots.length === 0) return;
+    for (const composed of selection.getComposedRanges({ shadowRoots })) {
+      const sharedRoot = SelectionLinkExtractor.findSharedRoot(composed.startContainer, composed.endContainer);
+      // No shared shadow root: either plain light DOM (already handled above)
+      // or the selection crosses sibling shadow trees with no common one.
+      if (!sharedRoot || sharedRoot === document) continue;
+      const start = SelectionLinkExtractor.retargetPoint(composed.startContainer, composed.startOffset, sharedRoot, false);
+      const end = SelectionLinkExtractor.retargetPoint(composed.endContainer, composed.endOffset, sharedRoot, true);
+      const range = document.createRange();
+      range.setStart(start.container, start.offset);
+      range.setEnd(end.container, end.offset);
+      this.processFragment(range.cloneContents());
+      this.processShadowHosts(range);
+    }
+  }
+
+  private findAllShadowRoots(root: ParentNode, acc: ShadowRoot[] = []): ShadowRoot[] {
+    for (const element of root.querySelectorAll('*')) {
+      if (element.shadowRoot) {
+	acc.push(element.shadowRoot);
+	this.findAllShadowRoots(element.shadowRoot, acc);
+      }
+    }
+    return acc;
+  }
+
+  // Roots from `node`'s own root up through each enclosing shadow host's root, ending in
+  // the top-level document. Used to find the innermost root shared by two boundary points.
+  private static rootChain(node: Node): Node[] {
+    const chain: Node[] = [];
+    let root: Node = node.getRootNode();
+    chain.push(root);
+    while (root instanceof ShadowRoot) {
+      root = root.host.getRootNode();
+      chain.push(root);
+    }
+    return chain;
+  }
+
+  private static findSharedRoot(a: Node, b: Node): Node | null {
+    const bChain = new Set(SelectionLinkExtractor.rootChain(b));
+    for (const root of SelectionLinkExtractor.rootChain(a)) {
+      if (bChain.has(root)) return root;
+    }
+    return null;
+  }
+
+  // Re-expresses (node, offset) relative to targetRoot: if node is already in targetRoot,
+  // it's returned unchanged; otherwise walks up through shadow hosts until reaching the
+  // one whose root is targetRoot, returning a boundary point just before (start) or after
+  // (end) that host, matching how the platform itself retargets cross-root boundary points.
+  private static retargetPoint(node: Node, offset: number, targetRoot: Node, isEnd: boolean): { container: Node, offset: number } {
+    let container = node;
+    let currentOffset = offset;
+    while (container.getRootNode() !== targetRoot) {
+      const root = container.getRootNode();
+      if (!(root instanceof ShadowRoot)) break;
+      const host = root.host;
+      const parent = host.parentNode;
+      if (!parent) return { container: host, offset: 0 };
+      container = parent;
+      currentOffset = Array.prototype.indexOf.call(parent.childNodes, host) + (isEnd ? 1 : 0);
+    }
+    return { container, offset: currentOffset };
   }
 
   processAnchorAncestor(selection: Selection) {
@@ -103,6 +185,7 @@ export class SelectionLinkExtractor {
       this.processFragment(range.cloneContents());
       this.processShadowHosts(range);
     }
+    this.processComposedShadowSelection(selection);
     // Special case if the selection is completely contained inside an anchor.
     if (this.links.length == 0 && selection.rangeCount > 0) {
       if (this.debug) { console.log('No links yet; checking for anchor ancestor') }

--- a/test/contentScript.test.ts
+++ b/test/contentScript.test.ts
@@ -379,6 +379,127 @@ test('processSelection: closed shadow root is left untouched', () => {
   expect(extractor.links).toHaveLength(0);
 });
 
+test('processSelection: recovers a selection collapsed entirely inside an open shadow root', () => {
+  // Real browsers retarget a selection that lies wholly inside an open shadow
+  // root to a zero-width point next to the host (see issue #32); simulate that
+  // by collapsing the selection, then simulate Selection.getComposedRanges()
+  // (unsupported by happy-dom) resolving the true, non-collapsed boundary.
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = '<div id="host"></div>';
+  const host = document.getElementById('host')!;
+  const shadow = host.attachShadow({ mode: 'open' });
+  shadow.innerHTML = '<a href="http://localhost/shadow">Shadow link</a>';
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection()!;
+  selection.collapse(document.body, 1);
+  expect(selection.getRangeAt(0).collapsed).toBeTruthy();
+  (selection as any).getComposedRanges = () => [{
+    startContainer: shadow,
+    startOffset: 0,
+    endContainer: shadow,
+    endOffset: 1,
+  }];
+
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual(['http://localhost/shadow']);
+  expect(extractor.labels).toEqual(['Shadow link']);
+});
+
+test('processSelection: recovers a selection collapsed inside a deeply nested shadow root', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = '<div id="host"></div>';
+  const host = document.getElementById('host')!;
+  const shadow = host.attachShadow({ mode: 'open' });
+  shadow.innerHTML = '<div id="inner-host"></div>';
+  const innerHost = shadow.getElementById('inner-host')!;
+  const innerShadow = innerHost.attachShadow({ mode: 'open' });
+  innerShadow.innerHTML = '<a href="http://localhost/nested">Nested link</a>';
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection()!;
+  selection.collapse(document.body, 1);
+  expect(selection.getRangeAt(0).collapsed).toBeTruthy();
+  (selection as any).getComposedRanges = () => [{
+    startContainer: innerShadow,
+    startOffset: 0,
+    endContainer: innerShadow,
+    endOffset: 1,
+  }];
+
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual(['http://localhost/nested']);
+  expect(extractor.labels).toEqual(['Nested link']);
+});
+
+test('processSelection: recovers a selection spanning sibling shadow hosts under a shared shadow root', () => {
+  // Mirrors a card/tile layout (e.g. a list of results) where each tile is its
+  // own custom element with its own shadow root, all hosted inside a shared
+  // "container" component's shadow root. The middle tile is only reachable by
+  // scanning inside the shared root, not by name, exercising processShadowHosts
+  // being handed a ShadowRoot (rather than an Element) as commonAncestorContainer.
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = '<div id="browser"></div>';
+  const browserHost = document.getElementById('browser')!;
+  const browserShadow = browserHost.attachShadow({ mode: 'open' });
+  browserShadow.innerHTML = '<div id="tile1"></div><div id="tile2"></div><div id="tile3"></div>';
+
+  const tileShadows = ['tile1', 'tile2', 'tile3'].map((id, i) => {
+    const tile = browserShadow.getElementById(id)!;
+    const tileShadow = tile.attachShadow({ mode: 'open' });
+    tileShadow.innerHTML = `<a href="http://localhost/${id}">Tile ${i + 1}</a>`;
+    return tileShadow;
+  });
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection()!;
+  selection.collapse(document.body, 1);
+  expect(selection.getRangeAt(0).collapsed).toBeTruthy();
+  (selection as any).getComposedRanges = () => [{
+    startContainer: tileShadows[0],
+    startOffset: 0,
+    endContainer: tileShadows[2],
+    endOffset: 1,
+  }];
+
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual([
+    'http://localhost/tile1',
+    'http://localhost/tile2',
+    'http://localhost/tile3',
+  ]);
+  expect(extractor.labels).toEqual(['Tile 1', 'Tile 2', 'Tile 3']);
+});
+
+test('processSelection: getComposedRanges spanning disconnected shadow trees is skipped, not thrown', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = '<div id="host"></div>';
+  const host = document.getElementById('host')!;
+  const shadow = host.attachShadow({ mode: 'open' });
+  shadow.innerHTML = '<a href="http://localhost/shadow">Shadow link</a>';
+
+  const detachedHost = document.createElement('div');
+  const detachedShadow = detachedHost.attachShadow({ mode: 'open' });
+  detachedShadow.innerHTML = '<a href="http://localhost/detached">Detached link</a>';
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection()!;
+  selection.collapse(document.body, 1);
+  (selection as any).getComposedRanges = () => [{
+    startContainer: shadow,
+    startOffset: 0,
+    endContainer: detachedShadow,
+    endOffset: 1,
+  }];
+
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toHaveLength(0);
+});
+
 test('Anchor ancestor is found', () => {
   document.body.innerHTML = `<a href="http://localhost/a">
 a<div id="child">b</div>


### PR DESCRIPTION
## Summary
- Fixes #30
- Verified live on https://archive.org/details/audio_bookspoetry

When the whole selection is inside an open shadow root, browsers retarget `Selection.getRangeAt()`'s boundary points to the same spot next to the shadow host, collapsing the `Range` to zero width. A collapsed `Range` can't `intersectsNode()` anything and `cloneContents()` returns nothing, so links were silently missed even though `processShadowHosts` (added in #34) can otherwise walk into shadow trees fine.

`processComposedShadowSelection()` uses `Selection.getComposedRanges()` (Chrome 127+, Firefox 142+) to recover the true boundary points, then walks up through nested shadow hosts to find the innermost root actually shared by both ends and rebuilds a real `Range` scoped to it — handling both "selection fully inside one shadow root" and "selection spans sibling shadow-hosted elements (e.g. tiles in a list) under a shared shadow-root ancestor." Older browsers without `getComposedRanges` fall back to the prior behavior (same graceful-degradation pattern already used for `system.display`/`tabGroups`).

Also fixes a latent bug in `processShadowHosts`: it assumed `range.commonAncestorContainer` is always an `Element`, but a range built inside a `ShadowRoot` can have the `ShadowRoot` itself as `commonAncestorContainer` — which isn't an `Element` and has no `parentElement`, causing it to silently no-op. Checks `nodeType` now instead of `instanceof`, which can also misfire across realms (confirmed via a happy-dom test-environment quirk while writing tests for this).

Also updates `CHANGELOG.md` with a new "Version 1.8.6" section covering this PR plus #33 and #34.

## Test plan
- [x] Selection collapsed entirely inside a single open shadow root
- [x] Selection collapsed inside a deeply nested shadow root
- [x] Selection spanning sibling shadow hosts under a shared shadow-root ancestor
- [x] Composed range spanning disconnected shadow trees is skipped, not thrown
- [x] `bunx vitest run` — 115/115 passing
- [x] `bunx tsc --noEmit` — clean
- [x] Manually verified on https://archive.org/details/audio_bookspoetry (the page from #30) after rebuilding the extension