### PR TITLE
Fix popup filter/error bugs, add keyboard nav, extract more links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@
     rows; Space toggles the focused row's checkbox
   * Focusing a row via the keyboard highlights the corresponding link on
     the page, matching the existing mouse-hover behavior
+* Extract links from image-map areas and formaction buttons (#24)
+  * `<area href>` inside `<map>` (image maps) and `<button>`/`<input
+    type="submit"|"image">` with a `formaction` attribute are now picked up
+    alongside `<a href>`, in the light DOM, inside open shadow roots, and in
+    the "selection collapsed inside a single link" special case
+  * `<area>` labels fall back to the element's `alt` attribute, since it has
+    no text content of its own
 # Version 1.8.6
 * Show `[empty]` for links with no text, not just missing text (#33)
 * Traverse open shadow roots when extracting links (#34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
     title/subtitle messaging used everywhere else in the popup
   * Now shows "Unable to open links" as the title with the underlying
     error as the subtitle
+* Add keyboard navigation to the popup's link list
+  * ArrowUp/ArrowDown move focus across the currently visible (unfiltered)
+    rows; Space toggles the focused row's checkbox
+  * Focusing a row via the keyboard highlights the corresponding link on
+    the page, matching the existing mouse-hover behavior
 # Version 1.8.6
 * Show `[empty]` for links with no text, not just missing text (#33)
 * Traverse open shadow roots when extracting links (#34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Next version
+* Fix a crash in the popup's link filter when a regex match ended at the very
+  last character of the link list
+  * `highlightRegex` dereferenced a possibly-null `TreeWalker` node after
+    walking off the end of the text, throwing and aborting highlighting of
+    any earlier matches in the same filter pass
+  * Also fixes a related off-by-one that could wrap a spurious empty
+    highlight span around the start of the next text node when a match
+    landed exactly on a node boundary
 # Version 1.8.6
 * Show `[empty]` for links with no text, not just missing text (#33)
 * Traverse open shadow roots when extracting links (#34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   * Moving focus to the filter while the native keypress is still bubbling
     was already enough for the browser to deliver the character there;
     the redispatch was unnecessary as well as broken
+* Show a friendly message when opening links fails
+  * The popup's Open button showed the raw `Error` object's default string
+    (e.g. `Error: No group with id: 12345.`) instead of the curated
+    title/subtitle messaging used everywhere else in the popup
+  * Now shows "Unable to open links" as the title with the underlying
+    error as the subtitle
 # Version 1.8.6
 * Show `[empty]` for links with no text, not just missing text (#33)
 * Traverse open shadow roots when extracting links (#34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
   * Also fixes a related off-by-one that could wrap a spurious empty
     highlight span around the start of the next text node when a match
     landed exactly on a node boundary
+* Fix a console error on every keystroke in the popup
+  * The "type anywhere to jump into the filter" handler redispatched the
+    same (already-dispatching) keypress event onto the filter, which is a
+    DOM-spec violation and always threw `InvalidStateError`
+  * Moving focus to the filter while the native keypress is still bubbling
+    was already enough for the browser to deliver the character there;
+    the redispatch was unnecessary as well as broken
 # Version 1.8.6
 * Show `[empty]` for links with no text, not just missing text (#33)
 * Traverse open shadow roots when extracting links (#34)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ const CHROME_EXECUTABLE = path.join(
 
 export default defineConfig({
   testDir: './test',
-  testMatch: ['**/e2e.test.ts'],
+  testMatch: ['**/e2e.test.ts', '**/e2e-popup-behavior.test.ts'],
   timeout: 30000,
   use: {
     headless: false,  // Chrome extensions require non-headless or headed mode

--- a/src/contentScript/extractor.ts
+++ b/src/contentScript/extractor.ts
@@ -1,7 +1,15 @@
+// <area href> (image maps) shares HTMLAnchorElement's .href behavior via
+// HTMLHyperlinkElementUtils; formaction-bearing submit buttons/inputs use
+// .formAction instead — see LinkElement.linkURL below.
+type LinkElement = HTMLAnchorElement | HTMLAreaElement | HTMLButtonElement | HTMLInputElement;
+
+const LINK_ELEMENT_SELECTOR =
+  'a[href], area[href], button[formaction], input[type="submit"][formaction], input[type="image"][formaction]';
+
 export class SelectionLinkExtractor {
   labels: string[] = [];
   links: string[] = [];
-  anchors: HTMLAnchorElement[] = [];
+  anchors: LinkElement[] = [];
   valid: boolean = false;
   debug: boolean = false;
 
@@ -17,20 +25,24 @@ export class SelectionLinkExtractor {
     this.anchors = [];
   }
 
+  private static linkURL(el: LinkElement): string {
+    return (el instanceof HTMLButtonElement || el instanceof HTMLInputElement) ? el.formAction : el.href;
+  }
+
   processFragment(documentFragment: DocumentFragment) {
     const base = document.head.querySelector('base');
     const baseURL = base ? base.href : window.location.href;
-    for (const anchor of this.collectAnchors(documentFragment)) {
+    for (const anchor of this.collectLinkElements(documentFragment)) {
       try {
-	const url = new URL(anchor.href, baseURL);
+	const url = new URL(SelectionLinkExtractor.linkURL(anchor), baseURL);
 	if (url.protocol.startsWith('http')) {
 	  this.links.push(url.href);
 	  if (this.debug) { console.log('anchor:', anchor) };
-	  this.labels.push(anchor.textContent?.trim() || '[empty]');
+	  this.labels.push(anchor.textContent?.trim() || anchor.getAttribute('alt')?.trim() || '[empty]');
 	  this.anchors.push(anchor);
 	}
       } catch {
-	console.log('Invalid URL', anchor.href);
+	console.log('Invalid URL', SelectionLinkExtractor.linkURL(anchor));
       }
     }
     if (this.debug) { console.log('Done processing fragment') }
@@ -39,14 +51,14 @@ export class SelectionLinkExtractor {
   // Cloning a selection (Range.cloneContents) never carries open shadow
   // roots along with their hosts, so this recursion only bears fruit when
   // called on a *live* shadow root (see processShadowHosts below).
-  private collectAnchors(root: DocumentFragment | ShadowRoot): HTMLAnchorElement[] {
-    const anchors = Array.from(root.querySelectorAll('a[href]')) as HTMLAnchorElement[];
+  private collectLinkElements(root: DocumentFragment | ShadowRoot): LinkElement[] {
+    const elements = Array.from(root.querySelectorAll(LINK_ELEMENT_SELECTOR)) as LinkElement[];
     for (const element of root.querySelectorAll('*')) {
       if (element.shadowRoot) {
-	anchors.push(...this.collectAnchors(element.shadowRoot));
+	elements.push(...this.collectLinkElements(element.shadowRoot));
       }
     }
-    return anchors;
+    return elements;
   }
 
   // Shadow trees aren't part of the light DOM that Range.cloneContents()
@@ -151,12 +163,12 @@ export class SelectionLinkExtractor {
     if (node) {
       if (this.debug) { console.log('processing node', node) }
       const element = node instanceof Element ? node as Element : node.parentElement!;
-      // See if we are in an anchor.
-      const result = element.closest('a')
+      // See if we are in a link-bearing element.
+      const result = element.closest(LINK_ELEMENT_SELECTOR)
       if (result != null) {
-	const anchor = result as HTMLAnchorElement;
+	const anchor = result as LinkElement;
 	try {
-	  const url = new URL(anchor.href, window.location.href);
+	  const url = new URL(SelectionLinkExtractor.linkURL(anchor), window.location.href);
 	  console.debug(`Considering ${url.href}`);
 	  if (url.protocol.startsWith('http')) {
 	    console.debug(`Adding ${url.href}`);
@@ -165,7 +177,7 @@ export class SelectionLinkExtractor {
 	    this.anchors.push(anchor);
 	  }
 	} catch {
-	  console.log('Invalid URL', anchor.href);
+	  console.log('Invalid URL', SelectionLinkExtractor.linkURL(anchor));
 	}
       }
       if (this.debug) { console.log('Done processing fragment') }

--- a/src/popup/index.css
+++ b/src/popup/index.css
@@ -315,6 +315,12 @@ div.row:hover {
   background: var(--row-hover);
 }
 
+div.row:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  background: var(--row-hover);
+}
+
 div.row:has(input:checked) {
   background: var(--row-checked);
 }

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -348,9 +348,14 @@ const setupFilter = function() {
       event.preventDefault();
     }
   });
-  document.body.addEventListener('keypress', (event) => {
+  document.body.addEventListener('keypress', () => {
+    // Moving focus synchronously, while the native keypress is still
+    // bubbling, is enough for the browser to insert the character being
+    // typed into the (newly focused) filter itself — no redispatch needed.
+    // (Redispatching the same event further throws: it's a DOM-spec
+    // violation to dispatch an event that's already mid-dispatch,
+    // regardless of which element originated it.)
     filterInput.focus();
-    filterInput.dispatchEvent(event);
   });
 }
 

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -125,7 +125,7 @@ const openLinks = async (event: Event) => {
     try {
       await makeTabsForLinks([links[0]], options)
     } catch (e: any) {
-      showError(e)
+      showError('Unable to open links', e?.message ?? String(e))
       throw e
     }
     // Open the rest of the links in a a new righthand window
@@ -135,7 +135,7 @@ const openLinks = async (event: Event) => {
     try {
       await makeTabsForLinks(links.slice(1), options)
     } catch (e: any) {
-      showError(e)
+      showError('Unable to open links', e?.message ?? String(e))
       throw e
     }
   } else {
@@ -148,7 +148,7 @@ const openLinks = async (event: Event) => {
       console.log('Making tabs with options:', options)
       await makeTabsForLinks(links, options)
     } catch (e: any) {
-      showError(e)
+      showError('Unable to open links', e?.message ?? String(e))
       throw e
     }
   }

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -177,6 +177,7 @@ const addLinkCheckboxes = async (links: string[], labels: string[], session: OSL
     rowElement.addEventListener('mouseout', async () => {
       await session.unhighlight();
     })
+    rowElement.tabIndex = 0;
     formElement.appendChild(rowElement);
 
     const inputElement = document.createElement('input');
@@ -210,6 +211,57 @@ const renderForm = async function(links: string[], labels: string[], session: OS
     return;
   }
   await addLinkCheckboxes(links, labels, session);
+  setupKeyboardNav(session);
+}
+
+// ArrowUp/ArrowDown move a roving focus across visible (non-filtered) rows;
+// Space toggles the focused row's checkbox. Mirrors mouseover/mouseout's
+// session.highlight()/unhighlight() calls for parity with hover.
+const setupKeyboardNav = (session: OSLSession) => {
+  const container = document.getElementById('select-links-div')!;
+
+  const visibleRows = (): HTMLElement[] =>
+    Array.from(container.querySelectorAll<HTMLElement>('div.row:not(.invisible)'));
+
+  document.addEventListener('keydown', async (event) => {
+    if (!container.isConnected) {
+      // A stale listener from a previous render (e.g. a leftover popup
+      // instance); the current render's own listener handles this event.
+      return;
+    }
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp' && event.key !== ' ') {
+      return;
+    }
+    const currentRow = (document.activeElement as HTMLElement | null)?.closest?.('div.row') as HTMLElement | null;
+
+    if (event.key === ' ') {
+      // Only steal Space when a row (not e.g. the filter) has focus, so
+      // typing a space into the filter keeps working normally.
+      if (!currentRow) return;
+      event.preventDefault();
+      const checkbox = currentRow.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+      checkbox.checked = !checkbox.checked;
+      return;
+    }
+
+    const rows = visibleRows();
+    if (rows.length === 0) return;
+    event.preventDefault();
+    const currentIdx = currentRow ? rows.indexOf(currentRow) : -1;
+    const nextIdx = event.key === 'ArrowDown'
+      ? Math.min(currentIdx + 1, rows.length - 1)
+      : Math.max(currentIdx - 1, 0);
+    const target = rows[nextIdx];
+    target.focus();
+    const allRows = Array.from(container.querySelectorAll('div.row'));
+    await session.highlight(allRows.indexOf(target));
+  });
+
+  container.addEventListener('focusout', async (event: FocusEvent) => {
+    if (!container.contains(event.relatedTarget as Node)) {
+      await session.unhighlight();
+    }
+  });
 }
 
 const highlightRegex = function(root: Element, regex: RegExp) {

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -245,7 +245,7 @@ const highlightRegex = function(root: Element, regex: RegExp) {
     );
 
     // Highlight subspans till the end of the match
-    while (node && curIndex <= endIndex) {
+    while (node && curIndex < endIndex) {
       const text = node.nodeValue!;
       console.log(
         `Looking for match end ${endIndex} in node (${curIndex}, ${curIndex + text.length})`,
@@ -276,7 +276,7 @@ const highlightRegex = function(root: Element, regex: RegExp) {
       curIndex += text.length;
       nodeMatchStart = 0;
       node = nextNode! as Element;
-      console.log('Next node is', node.nodeValue);
+      console.log('Next node is', node?.nodeValue);
     }
   }
 }

--- a/test/contentScript.test.ts
+++ b/test/contentScript.test.ts
@@ -521,3 +521,203 @@ a<div id="child">b</div>
     'b',
   ]);
 });
+
+// happy-dom 14.x has no HTMLAreaElement implementation: document.createElement('area')
+// (or innerHTML-parsed <area>) yields a plain HTMLElement whose .href getter is always
+// undefined, regardless of the href attribute. Range.cloneContents() (used by the
+// processSelection path) clones nodes, which would drop any Object.defineProperty
+// override placed on the original — so, as with the "<base> href" test above, we call
+// processFragment directly with elements whose .href getter we override ourselves to
+// simulate what a real browser (where <area> implements HTMLHyperlinkElementUtils)
+// would report.
+test('processFragment: <area href> image map links are extracted with alt as label', () => {
+  window.location.href = 'http://localhost/';
+  const extractor = new SelectionLinkExtractor();
+  const fragment = document.createDocumentFragment();
+  const map = document.createElement('map');
+  const area1 = document.createElement('area');
+  area1.setAttribute('href', 'http://localhost/room1');
+  area1.setAttribute('alt', 'Room 1');
+  Object.defineProperty(area1, 'href', { get: () => 'http://localhost/room1' });
+  const area2 = document.createElement('area');
+  area2.setAttribute('href', 'http://localhost/room2');
+  area2.setAttribute('alt', 'Room 2');
+  Object.defineProperty(area2, 'href', { get: () => 'http://localhost/room2' });
+  map.appendChild(area1);
+  map.appendChild(area2);
+  fragment.appendChild(map);
+  extractor.processFragment(fragment);
+  expect(extractor.links).toEqual([
+    'http://localhost/room1',
+    'http://localhost/room2',
+  ]);
+  expect(extractor.labels).toEqual([
+    'Room 1',
+    'Room 2',
+  ]);
+});
+
+test('processFragment: <area> with no alt attribute falls back to [empty] label', () => {
+  window.location.href = 'http://localhost/';
+  const extractor = new SelectionLinkExtractor();
+  const fragment = document.createDocumentFragment();
+  const area = document.createElement('area');
+  area.setAttribute('href', 'http://localhost/room1');
+  Object.defineProperty(area, 'href', { get: () => 'http://localhost/room1' });
+  fragment.appendChild(area);
+  extractor.processFragment(fragment);
+  expect(extractor.links).toEqual(['http://localhost/room1']);
+  expect(extractor.labels).toEqual(['[empty]']);
+});
+
+test('processSelection: <button formaction> is extracted using its text as label', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = `<button formaction="http://localhost/submit">Send</button>`;
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  selection.selectAllChildren(document.body);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual(['http://localhost/submit']);
+  expect(extractor.labels).toEqual(['Send']);
+});
+
+test('processSelection: <input type="submit" formaction> is extracted', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = `<input type="submit" formaction="http://localhost/submit" value="Go">`;
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  selection.selectAllChildren(document.body);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual(['http://localhost/submit']);
+  expect(extractor.labels).toEqual(['[empty]']);
+});
+
+test('processSelection: <input type="image" formaction> is extracted', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = `<input type="image" formaction="http://localhost/submit-image">`;
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  selection.selectAllChildren(document.body);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual(['http://localhost/submit-image']);
+  expect(extractor.labels).toEqual(['[empty]']);
+});
+
+test('processSelection: formaction on a plain text input is ignored', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = `<input type="text" formaction="http://localhost/ignored">`;
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  selection.selectAllChildren(document.body);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toHaveLength(0);
+});
+
+test('processSelection: <button> without formaction is ignored', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = `<button>Click me</button>`;
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  selection.selectAllChildren(document.body);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toHaveLength(0);
+});
+
+test('processFragment: <button formaction> resolves against <base> href like anchors', () => {
+  // Same workaround as "processFragment: uses <base> href when present in document
+  // head" above: happy-dom would otherwise resolve the IDL formAction property
+  // against window.location before processFragment sees it, so override the getter
+  // to return the raw relative value and let the extractor's own base-URL lookup
+  // (document.head.querySelector('base')) do the resolution.
+  document.head.innerHTML = '<base href="https://base.example.com/deep/link/">';
+  const extractor = new SelectionLinkExtractor();
+  const fragment = document.createDocumentFragment();
+  const button = document.createElement('button');
+  button.setAttribute('formaction', '../submit');
+  Object.defineProperty(button, 'formAction', { get: () => '../submit' });
+  button.textContent = 'Go';
+  fragment.appendChild(button);
+  extractor.processFragment(fragment);
+  document.head.innerHTML = '';
+  expect(extractor.links).toEqual(['https://base.example.com/deep/submit']);
+  expect(extractor.labels).toEqual(['Go']);
+});
+
+test('processAnchorAncestor: recognizes a formaction button as link ancestor', () => {
+  document.body.innerHTML = `<button formaction="http://localhost/submit">
+Send<span id="child">it</span>
+</button>`;
+  window.location.href = 'http://localhost/';
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  const child = document.getElementById('child');
+  selection.selectAllChildren(child);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual(['http://localhost/submit']);
+  expect(extractor.labels).toEqual(['it']);
+});
+
+test('processAnchorAncestor: recognizes an <area> itself as link ancestor', () => {
+  // processAnchorAncestor reads selection.anchorNode directly from the live document
+  // (no Range.cloneContents() involved), so the .href override on the live element
+  // (see the happy-dom HTMLAreaElement note above) is honored here.
+  document.body.innerHTML = `<map name="m"><area shape="rect" coords="0,0,10,10" href="http://localhost/room1" alt="Room 1"></map>`;
+  window.location.href = 'http://localhost/';
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  const area = document.querySelector('area')!;
+  Object.defineProperty(area, 'href', { get: () => 'http://localhost/room1' });
+  selection.selectAllChildren(area);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual(['http://localhost/room1']);
+});
+
+test('processSelection: traverses open shadow root for formaction buttons', () => {
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = '<p>text</p><div id="host"></div>';
+  const host = document.getElementById('host')!;
+  const shadow = host.attachShadow({ mode: 'open' });
+  shadow.innerHTML = '<button formaction="http://localhost/shadow-submit">Go</button>';
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  selection.selectAllChildren(document.body);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual(['http://localhost/shadow-submit']);
+  expect(extractor.labels).toEqual(['Go']);
+});
+
+test('processSelection: traverses open shadow root for <area> elements', () => {
+  // processShadowHosts calls processFragment on the *live* shadow root (shadow trees
+  // aren't cloned by Range.cloneContents()), so the .href override below (see the
+  // happy-dom HTMLAreaElement note above) survives here, unlike the plain light-DOM
+  // area tests which had to use processFragment directly.
+  window.location.href = 'http://localhost/';
+  document.body.innerHTML = '<div id="host"></div>';
+  const host = document.getElementById('host')!;
+  const shadow = host.attachShadow({ mode: 'open' });
+  shadow.innerHTML = '<map name="m"><area shape="rect" coords="0,0,10,10" href="http://localhost/shadow-area" alt="Shadow Area"></map>';
+  const area = shadow.querySelector('area')!;
+  Object.defineProperty(area, 'href', { get: () => 'http://localhost/shadow-area' });
+
+  const extractor = new SelectionLinkExtractor();
+  const selection = document.getSelection();
+  selection.selectAllChildren(document.body);
+  extractor.processSelection();
+  expect(extractor.valid).toBeTruthy();
+  expect(extractor.links).toEqual(['http://localhost/shadow-area']);
+  expect(extractor.labels).toEqual(['Shadow Area']);
+});

--- a/test/e2e-firefox.test.ts
+++ b/test/e2e-firefox.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { buildPermissiveExtension, startTestServer, type TestServer } from './e2e-helpers';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const EXTENSION_PATH = path.resolve(__dirname, '../build');
@@ -13,10 +14,38 @@ const ADDON_ID = '@open-selected-links-ff';
 const GD_PORT = 4455;
 const GD_BASE = `http://localhost:${GD_PORT}`;
 
+// W3C WebDriver normalized key values for the Actions API.
+const ARROW_DOWN = '';
+const SPACE = '';
+
+// Mirrors the fixtures in test/e2e-popup-behavior.test.ts (the Chrome
+// equivalent of these tests) so both browsers exercise the same scenarios.
+const TEST_PAGE_HTML = `<!DOCTYPE html>
+<html><body>
+<p id="content">Check out <a href="https://example.com/first">first item</a> and
+<a href="https://example.com/second">last item</a></p>
+</body></html>`;
+
+const AREA_AND_FORMACTION_HTML = `<!DOCTYPE html>
+<html><body>
+<div id="content">
+  <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBTAA7"
+       usemap="#planmap" width="10" height="10">
+  <map name="planmap">
+    <area shape="rect" coords="0,0,10,10" href="https://example.com/room-one" alt="Room One">
+  </map>
+  <form>
+    <button formaction="https://example.com/submit-link">Submit Link</button>
+  </form>
+</div>
+</body></html>`;
+
 let geckodriverProcess: ChildProcess;
 let sessionId: string;
 let extensionUuid: string;
 let profileDir: string;
+let basicServer: TestServer;
+let areaServer: TestServer;
 
 async function gd(method: string, endpoint: string, body?: any): Promise<any> {
   const res = await fetch(`${GD_BASE}${endpoint}`, {
@@ -51,7 +80,100 @@ async function executeScript(script: string, args: any[] = []): Promise<any> {
   return gd('POST', `/session/${sessionId}/execute/sync`, { script, args });
 }
 
+async function executeAsyncScript(script: string, args: any[] = []): Promise<any> {
+  return gd('POST', `/session/${sessionId}/execute/async`, { script, args });
+}
+
+async function click(elementId: string) {
+  await gd('POST', `/session/${sessionId}/element/${elementId}/click`, {});
+}
+
+async function sendKeys(elementId: string, text: string) {
+  await gd('POST', `/session/${sessionId}/element/${elementId}/value`, { text });
+}
+
+async function keyPress(value: string) {
+  await gd('POST', `/session/${sessionId}/actions`, {
+    actions: [{ type: 'key', id: 'kbd', actions: [{ type: 'keyDown', value }, { type: 'keyUp', value }] }],
+  });
+}
+
+async function getWindowHandle(): Promise<string> {
+  return gd('GET', `/session/${sessionId}/window`);
+}
+
+async function switchWindow(handle: string) {
+  await gd('POST', `/session/${sessionId}/window`, { handle });
+}
+
+// Waits for the popup's link rows to render — content-script injection and
+// the round trip to get_links happen asynchronously after navigation.
+async function waitForRows(timeoutMs = 10000): Promise<number> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const count = await executeScript(`return document.querySelectorAll('div.row').length;`);
+    if (count > 0) return count;
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }
+  return 0;
+}
+
+// Opens `pageUrl` in the session's original window, selects its #content
+// element, opens a second tab for the popup pointed at that tab (via the
+// `?tab=` query param the popup supports for tests), and waits for its link
+// rows to render. Also installs a window-level error listener in the popup
+// so tests can assert no uncaught exceptions occurred. Returns the original
+// window's handle — pass it to closePopupWindow() for cleanup.
+async function openTestPageAndPopup(pageUrl: string): Promise<{ homeHandle: string; tabId: number }> {
+  const homeHandle = await getWindowHandle();
+  await navigateTo(pageUrl);
+  await executeScript(`
+    const el = document.getElementById('content');
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+  `);
+
+  await gd('POST', `/session/${sessionId}/window/new`, { type: 'tab' });
+  const handles: string[] = await gd('GET', `/session/${sessionId}/window/handles`);
+  const popupHandle = handles.find(h => h !== homeHandle)!;
+  await switchWindow(popupHandle);
+
+  // Navigate to an extension page first so `browser.*` is available in this
+  // context — a fresh tab starts on about:blank, which has no such API.
+  await navigateTo(`moz-extension://${extensionUuid}/html/popup.html`);
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  const tabId = await executeAsyncScript(`
+    const callback = arguments[arguments.length - 1];
+    browser.tabs.query({}).then(tabs => {
+      const t = tabs.find(t => t.url && t.url.startsWith('http'));
+      callback(t ? t.id : null);
+    });
+  `);
+
+  await navigateTo(`moz-extension://${extensionUuid}/html/popup.html?tab=${tabId}`);
+  await executeScript(`
+    window.__oslErrors = [];
+    window.addEventListener('error', (e) => window.__oslErrors.push(String(e.error || e.message)));
+    window.addEventListener('unhandledrejection', (e) => window.__oslErrors.push(String(e.reason)));
+  `);
+  await waitForRows();
+
+  return { homeHandle, tabId };
+}
+
+async function closePopupWindow(homeHandle: string) {
+  await gd('DELETE', `/session/${sessionId}/window`);
+  await switchWindow(homeHandle);
+}
+
 test.beforeAll(async () => {
+  basicServer = await startTestServer(TEST_PAGE_HTML);
+  areaServer = await startTestServer(AREA_AND_FORMACTION_HTML);
+
   profileDir = mkdtempSync(path.join(tmpdir(), 'ff-osl-test-'));
 
   geckodriverProcess = spawn(GECKODRIVER, [`--port=${GD_PORT}`, '--log=warn'], {
@@ -76,9 +198,14 @@ test.beforeAll(async () => {
   });
   sessionId = session.sessionId;
 
-  // Create XPI from the Firefox build directory
+  // Chrome's activeTab-equivalent gesture (a real toolbar click) can't be
+  // simulated via WebDriver either; sideload a copy of the build with a
+  // narrow, localhost-only host_permissions grant instead — same technique
+  // test/e2e-helpers.ts uses for the Chrome e2e suite. The extra permission
+  // doesn't affect the pre-existing UI-presence tests below.
+  const permissiveDir = buildPermissiveExtension(EXTENSION_PATH);
   const xpiPath = path.join(tmpdir(), 'osl-ff-test.zip');
-  execSync(`cd "${EXTENSION_PATH}" && zip -r "${xpiPath}" . -x "*.map"`, { stdio: 'ignore' });
+  execSync(`cd "${permissiveDir}" && zip -r "${xpiPath}" . -x "*.map"`, { stdio: 'ignore' });
 
   // Sideload the extension via geckodriver's addon install endpoint
   const xpiBase64 = readFileSync(xpiPath).toString('base64');
@@ -108,6 +235,8 @@ test.beforeAll(async () => {
 test.afterAll(async () => {
   if (sessionId) await gd('DELETE', `/session/${sessionId}`).catch(() => {});
   geckodriverProcess?.kill();
+  basicServer?.close();
+  areaServer?.close();
 });
 
 test('extension loads and popup page is accessible on Firefox', async () => {
@@ -144,5 +273,110 @@ test('tab group UI visibility matches tabGroups support on Firefox', async () =>
     expect(display).not.toBe('none');
   } else {
     expect(display).toBe('none');
+  }
+});
+
+test('filter regex ending at the very end of the link list does not crash on Firefox', async () => {
+  const { homeHandle } = await openTestPageAndPopup(basicServer.url);
+  try {
+    // "last item" is the very last text in #select-links-div; matching "item"
+    // here (and again earlier in "first item") reproduces the reverse-order
+    // highlightRegex crash fixed in src/popup/index.ts.
+    await executeScript(`
+      const el = document.getElementById('filter');
+      el.innerText = 'item';
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    `);
+    await new Promise(resolve => setTimeout(resolve, 300));
+
+    const errors = await executeScript(`return window.__oslErrors;`);
+    const highlightCount = await executeScript(
+      `return document.querySelectorAll('#select-links-div span.highlight').length;`,
+    );
+    expect(errors).toEqual([]);
+    expect(highlightCount).toBe(2);
+  } finally {
+    await closePopupWindow(homeHandle);
+  }
+});
+
+test('typing while focus is elsewhere moves focus to the filter without throwing on Firefox', async () => {
+  const { homeHandle } = await openTestPageAndPopup(basicServer.url);
+  try {
+    const toggleBtn = await findElement('#toggle-button'); // focus something that is NOT the filter
+    await click(toggleBtn);
+    await keyPress('x');
+    await new Promise(resolve => setTimeout(resolve, 300));
+
+    const errors = await executeScript(`return window.__oslErrors;`);
+    const activeIsFilter = await executeScript(
+      `return document.activeElement && document.activeElement.id === 'filter';`,
+    );
+    expect(errors).toEqual([]);
+    expect(activeIsFilter).toBe(true);
+    // Unlike Chrome, Firefox doesn't retroactively redirect the triggering
+    // keystroke's *character* into the newly-focused element — only the
+    // no-crash and focus-redirect behavior are asserted here. See the note
+    // in setupFilter (src/popup/index.ts) for why the removed redispatch
+    // could never have caused insertion in either browser.
+  } finally {
+    await closePopupWindow(homeHandle);
+  }
+});
+
+test('shows a friendly error message on a real tab-group failure on Firefox', async () => {
+  const { homeHandle } = await openTestPageAndPopup(basicServer.url);
+  try {
+    await executeScript(`document.querySelector('input[name="select-links"]').checked = true;`);
+    // A numeric tab-group id that doesn't exist makes the real
+    // browser.tabs.group() call reject (groupTabs doesn't catch it).
+    const tabGroupInput = await findElement('#tab-group-name');
+    await sendKeys(tabGroupInput, '999999999');
+    const openBtn = await findElement('#open-button');
+    await click(openBtn);
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    const errorTitle = await executeScript(`return document.getElementById('error').textContent;`);
+    const errorSub = await executeScript(`return document.getElementById('error_sub').textContent;`);
+    expect(errorTitle).toBe('Unable to open links');
+    expect(errorSub).toBeTruthy();
+  } finally {
+    await closePopupWindow(homeHandle);
+  }
+});
+
+test('keyboard navigation (ArrowDown/Space) selects a link without a mouse on Firefox', async () => {
+  const { homeHandle } = await openTestPageAndPopup(basicServer.url);
+  try {
+    await keyPress(ARROW_DOWN); // focuses the first row
+    await keyPress(ARROW_DOWN); // focuses the second row
+    await keyPress(SPACE); // toggles the second row's checkbox
+    await new Promise(resolve => setTimeout(resolve, 300));
+
+    const result = await executeScript(`
+      const rows = document.querySelectorAll('div.row');
+      return {
+        secondFocused: document.activeElement === rows[1],
+        secondChecked: rows[1].querySelector('input[type=checkbox]').checked,
+        firstChecked: rows[0].querySelector('input[type=checkbox]').checked,
+      };
+    `);
+    expect(result).toEqual({ secondFocused: true, secondChecked: true, firstChecked: false });
+  } finally {
+    await closePopupWindow(homeHandle);
+  }
+});
+
+test('extracts links from image-map areas and formaction buttons on Firefox', async () => {
+  const { homeHandle } = await openTestPageAndPopup(areaServer.url);
+  try {
+    const result = await executeScript(`
+      const anchors = Array.from(document.querySelectorAll('#select-links-div a'));
+      return { links: anchors.map(a => a.href), labels: anchors.map(a => a.textContent) };
+    `);
+    expect(result.links).toEqual(['https://example.com/room-one', 'https://example.com/submit-link']);
+    expect(result.labels).toEqual(['Room One', 'Submit Link']);
+  } finally {
+    await closePopupWindow(homeHandle);
   }
 });

--- a/test/e2e-helpers.ts
+++ b/test/e2e-helpers.ts
@@ -1,0 +1,43 @@
+// Shared helpers for e2e specs that need real link rows in the popup (not just
+// static UI presence, which is all test/e2e.test.ts checks).
+//
+// Chrome's `activeTab` — the only host-access permission this extension ships
+// with — is granted on a real user gesture on the toolbar icon, which
+// Playwright cannot simulate. These tests instead load a copy of the build
+// with a narrow, localhost-only `host_permissions` grant added, so the
+// content script can be injected into our own test pages without that
+// gesture. The patched copy lives in a temp directory; the checked-in
+// manifest and the shipped `build/` output are never touched.
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+export function buildPermissiveExtension(buildDir: string): string {
+  const dest = fs.mkdtempSync(path.join(os.tmpdir(), 'osl-e2e-'));
+  fs.cpSync(buildDir, dest, { recursive: true });
+  const manifestPath = path.join(dest, 'manifest.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  manifest.host_permissions = ['http://127.0.0.1/*'];
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  return dest;
+}
+
+export interface TestServer {
+  url: string;
+  close: () => void;
+}
+
+export function startTestServer(html: string): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(html);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ url: `http://127.0.0.1:${port}/`, close: () => server.close() });
+    });
+  });
+}

--- a/test/e2e-popup-behavior.test.ts
+++ b/test/e2e-popup-behavior.test.ts
@@ -99,3 +99,40 @@ test('filtering does not crash when a match ends at the very end of the link lis
   expect(pageErrors).toEqual([]);
   await expect(popup.locator('#select-links-div span.highlight')).toHaveCount(2);
 });
+
+test('typing while focus is elsewhere redirects into the filter without throwing', async () => {
+  const page = await context.newPage();
+  await page.goto(server.url);
+  await selectTestPageContent(page);
+  const tabId = await getTestPageTabId();
+  const popup = await openPopupForTab(tabId);
+
+  const pageErrors: string[] = [];
+  popup.on('pageerror', (err) => pageErrors.push(String(err)));
+
+  await popup.click('#toggle-button'); // focus something that is NOT the filter
+  await popup.keyboard.press('x');
+  await popup.waitForTimeout(200);
+
+  expect(pageErrors).toEqual([]);
+  await expect(popup.locator('#filter')).toBeFocused();
+  expect(await popup.locator('#filter').textContent()).toBe('x');
+});
+
+test('typing directly into the already-focused filter does not throw', async () => {
+  const page = await context.newPage();
+  await page.goto(server.url);
+  await selectTestPageContent(page);
+  const tabId = await getTestPageTabId();
+  const popup = await openPopupForTab(tabId);
+
+  const pageErrors: string[] = [];
+  popup.on('pageerror', (err) => pageErrors.push(String(err)));
+
+  await popup.click('#filter');
+  await popup.keyboard.type('Article');
+  await popup.waitForTimeout(200);
+
+  expect(pageErrors).toEqual([]);
+  expect(await popup.locator('#filter').textContent()).toBe('Article');
+});

--- a/test/e2e-popup-behavior.test.ts
+++ b/test/e2e-popup-behavior.test.ts
@@ -136,3 +136,24 @@ test('typing directly into the already-focused filter does not throw', async () 
   expect(pageErrors).toEqual([]);
   expect(await popup.locator('#filter').textContent()).toBe('Article');
 });
+
+test('a real Chrome error opening links shows a friendly title with the error as subtitle', async () => {
+  const page = await context.newPage();
+  await page.goto(server.url);
+  await selectTestPageContent(page);
+  const tabId = await getTestPageTabId();
+  const popup = await openPopupForTab(tabId);
+
+  await popup.locator('input[name="select-links"]').first().check();
+  // A numeric tab-group id that doesn't exist makes the real
+  // browser.tabs.group() call reject (groupTabs doesn't catch it).
+  await popup.fill('#tab-group-name', '999999999');
+  await popup.click('#open-button');
+  await popup.waitForTimeout(500);
+
+  await expect(popup.locator('#error')).toHaveText('Unable to open links');
+  const subtitle = await popup.locator('#error_sub').textContent();
+  expect(subtitle).toBeTruthy();
+  // The popup stays open on error instead of calling window.close().
+  expect(popup.isClosed()).toBe(false);
+});

--- a/test/e2e-popup-behavior.test.ts
+++ b/test/e2e-popup-behavior.test.ts
@@ -157,3 +157,20 @@ test('a real Chrome error opening links shows a friendly title with the error as
   // The popup stays open on error instead of calling window.close().
   expect(popup.isClosed()).toBe(false);
 });
+
+test('keyboard navigation: ArrowDown/Space select a link without a mouse', async () => {
+  const page = await context.newPage();
+  await page.goto(server.url);
+  await selectTestPageContent(page);
+  const tabId = await getTestPageTabId();
+  const popup = await openPopupForTab(tabId);
+
+  await popup.keyboard.press('ArrowDown'); // focuses the first row
+  await popup.keyboard.press('ArrowDown'); // focuses the second row
+  await popup.keyboard.press(' '); // toggles the second row's checkbox
+
+  const rows = popup.locator('div.row');
+  await expect(rows.nth(1)).toBeFocused();
+  await expect(rows.nth(1).locator('input[type="checkbox"]')).toBeChecked();
+  await expect(rows.nth(0).locator('input[type="checkbox"]')).not.toBeChecked();
+});

--- a/test/e2e-popup-behavior.test.ts
+++ b/test/e2e-popup-behavior.test.ts
@@ -1,0 +1,101 @@
+import { test, expect, chromium, type BrowserContext, type Page } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { buildPermissiveExtension, startTestServer, type TestServer } from './e2e-helpers';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Extension ID is stable because manifest.json includes a fixed public key;
+// it's unaffected by copying the build to a temp dir with host_permissions added.
+const CHROME_EXTENSION_ID = 'hcihcignkpajeehfnomlncinacagapdf';
+
+const TEST_PAGE_HTML = `<!DOCTYPE html>
+<html><body>
+<p id="content">Check out <a href="https://example.com/first">first item</a> and
+<a href="https://example.com/second">last item</a></p>
+</body></html>`;
+
+let extensionPath: string;
+let context: BrowserContext;
+let server: TestServer;
+
+test.beforeAll(() => {
+  extensionPath = buildPermissiveExtension(path.resolve(__dirname, '../build'));
+});
+
+test.beforeEach(async () => {
+  server = await startTestServer(TEST_PAGE_HTML);
+  context = await chromium.launchPersistentContext('', {
+    headless: false,
+    executablePath: (test.info().project.use as any).executablePath,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+      '--no-sandbox',
+    ],
+  });
+  if (context.serviceWorkers().length === 0) {
+    await context.waitForEvent('serviceworker');
+  }
+});
+
+test.afterEach(async () => {
+  await context.close();
+  server.close();
+});
+
+// Opens the popup pointed at the given tab (via the `?tab=` query param the
+// popup supports for tests) and waits for link rows to render.
+async function openPopupForTab(tabId: number): Promise<Page> {
+  const popup = await context.newPage();
+  await popup.goto(`chrome-extension://${CHROME_EXTENSION_ID}/html/popup.html?tab=${tabId}`);
+  await popup.waitForLoadState('domcontentloaded');
+  await popup.waitForFunction(() => document.getElementById('open-button') !== null);
+  await popup.waitForFunction(() => document.querySelectorAll('div.row').length > 0, { timeout: 5000 });
+  return popup;
+}
+
+async function getTestPageTabId(): Promise<number> {
+  const worker = context.serviceWorkers()[0];
+  return await worker.evaluate(async () => {
+    const tabs = await chrome.tabs.query({});
+    const t = tabs.find((t) => t.url && t.url.startsWith('http'));
+    return t!.id!;
+  });
+}
+
+async function selectTestPageContent(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const el = document.getElementById('content')!;
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+  });
+}
+
+test('filtering does not crash when a match ends at the very end of the link list', async () => {
+  const page = await context.newPage();
+  await page.goto(server.url);
+  await selectTestPageContent(page);
+  const tabId = await getTestPageTabId();
+  const popup = await openPopupForTab(tabId);
+
+  const pageErrors: string[] = [];
+  popup.on('pageerror', (err) => pageErrors.push(String(err)));
+
+  // "last item" is the very last text in #select-links-div; matching "item" here
+  // (and again earlier in "first item") reproduces the reverse-order highlightRegex
+  // crash: the end-of-text match is processed first and used to throw on
+  // node.nodeValue when walker.nextNode() returns null, aborting the earlier match.
+  await popup.evaluate(() => {
+    const el = document.getElementById('filter')!;
+    el.innerText = 'item';
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await popup.waitForTimeout(300);
+
+  expect(pageErrors).toEqual([]);
+  await expect(popup.locator('#select-links-div span.highlight')).toHaveCount(2);
+});

--- a/test/e2e-popup-behavior.test.ts
+++ b/test/e2e-popup-behavior.test.ts
@@ -174,3 +174,41 @@ test('keyboard navigation: ArrowDown/Space select a link without a mouse', async
   await expect(rows.nth(1).locator('input[type="checkbox"]')).toBeChecked();
   await expect(rows.nth(0).locator('input[type="checkbox"]')).not.toBeChecked();
 });
+
+const AREA_AND_FORMACTION_HTML = `<!DOCTYPE html>
+<html><body>
+<div id="content">
+  <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBTAA7"
+       usemap="#planmap" width="10" height="10">
+  <map name="planmap">
+    <area shape="rect" coords="0,0,10,10" href="https://example.com/room-one" alt="Room One">
+  </map>
+  <form>
+    <button formaction="https://example.com/submit-link">Submit Link</button>
+  </form>
+</div>
+</body></html>`;
+
+test('extracts links from image-map areas and formaction buttons', async () => {
+  const areaServer = await startTestServer(AREA_AND_FORMACTION_HTML);
+  try {
+    const page = await context.newPage();
+    await page.goto(areaServer.url);
+    await selectTestPageContent(page);
+    const tabId = await getTestPageTabId();
+    const popup = await openPopupForTab(tabId);
+
+    const links = await popup.locator('#select-links-div a').evaluateAll(
+      (anchors) => anchors.map((a) => (a as HTMLAnchorElement).href),
+    );
+    const labels = await popup.locator('#select-links-div a').allTextContents();
+
+    expect(links).toEqual([
+      'https://example.com/room-one',
+      'https://example.com/submit-link',
+    ]);
+    expect(labels).toEqual(['Room One', 'Submit Link']);
+  } finally {
+    areaServer.close();
+  }
+});

--- a/test/popup.test.ts
+++ b/test/popup.test.ts
@@ -629,3 +629,90 @@ describe('addLinkCheckboxes with duplicate URLs', () => {
     expect(rows[2].classList.contains('invisible')).toBe(false); // B: unique, shown
   });
 });
+
+describe('keyboard navigation', () => {
+  const pressKey = (key: string, target: Element = document.body) => {
+    const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+    target.dispatchEvent(event);
+    return event;
+  };
+
+  beforeEach(async () => {
+    vi.resetModules();
+    document.body.innerHTML = POPUP_HTML;
+    document.head.innerHTML = '';
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    });
+    setupBrowserMocks(
+      ['http://a.example/', 'http://b.example/', 'http://c.example/'],
+      ['A', 'B', 'C'],
+    );
+    await import('../src/popup/index.ts');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('ArrowDown moves focus onto the first row, then the next', () => {
+    const rows = document.querySelectorAll('div.row');
+    pressKey('ArrowDown');
+    expect(document.activeElement).toBe(rows[0]);
+    pressKey('ArrowDown');
+    expect(document.activeElement).toBe(rows[1]);
+  });
+
+  test('ArrowUp moves focus to the previous row', () => {
+    const rows = document.querySelectorAll('div.row');
+    pressKey('ArrowDown');
+    pressKey('ArrowDown');
+    pressKey('ArrowUp');
+    expect(document.activeElement).toBe(rows[0]);
+  });
+
+  test('ArrowUp/ArrowDown clamp at the first/last row', () => {
+    const rows = document.querySelectorAll('div.row');
+    pressKey('ArrowUp'); // already before the first row; clamps to the first
+    expect(document.activeElement).toBe(rows[0]);
+    pressKey('ArrowDown');
+    pressKey('ArrowDown');
+    pressKey('ArrowDown'); // past the last row; clamps to the last
+    expect(document.activeElement).toBe(rows[2]);
+  });
+
+  test('Space toggles the focused row\'s checkbox', () => {
+    const checkbox = document.querySelector('input[name="select-links"]') as HTMLInputElement;
+    pressKey('ArrowDown');
+    pressKey(' ');
+    expect(checkbox.checked).toBe(true);
+    pressKey(' ');
+    expect(checkbox.checked).toBe(false);
+  });
+
+  test('Space does nothing when no row is focused (e.g. the filter has focus)', () => {
+    const filter = document.getElementById('filter')!;
+    filter.focus();
+    const event = pressKey(' ', filter);
+    for (const cb of document.querySelectorAll<HTMLInputElement>('input[name="select-links"]')) {
+      expect(cb.checked).toBe(false);
+    }
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test('ArrowDown skips rows hidden by the filter', () => {
+    const filterDiv = document.getElementById('filter')!;
+    (filterDiv as any).innerText = 'B';
+    filterDiv.dispatchEvent(new Event('input'));
+
+    const rows = document.querySelectorAll('div.row');
+    expect(rows[1].classList.contains('invisible')).toBe(false);
+    expect(rows[0].classList.contains('invisible')).toBe(true);
+    expect(rows[2].classList.contains('invisible')).toBe(true);
+
+    pressKey('ArrowDown');
+    expect(document.activeElement).toBe(rows[1]);
+  });
+});

--- a/test/popup.test.ts
+++ b/test/popup.test.ts
@@ -295,6 +295,39 @@ describe('filterRows', () => {
   });
 });
 
+describe('body keypress redirect to filter', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    document.body.innerHTML = POPUP_HTML;
+    document.head.innerHTML = '';
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    });
+    setupBrowserMocks(['http://a.example/'], ['A']);
+    await import('../src/popup/index.ts');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('keystrokes typed elsewhere move focus to the filter without throwing', () => {
+    const filter = document.getElementById('filter')!;
+    const otherElement = document.getElementById('open-button')!;
+    const event = new KeyboardEvent('keypress', { key: 'a', bubbles: true, cancelable: true });
+    expect(() => otherElement.dispatchEvent(event)).not.toThrow();
+    expect(document.activeElement).toBe(filter);
+  });
+
+  test('keystrokes typed directly into the filter do not throw', () => {
+    const filter = document.getElementById('filter')!;
+    const event = new KeyboardEvent('keypress', { key: 'a', bubbles: true, cancelable: true });
+    expect(() => filter.dispatchEvent(event)).not.toThrow();
+  });
+});
+
 // Shared beforeEach body for setupIncognito describe blocks — only the
 // isAllowedIncognitoAccess mock differs between them.
 const makeIncognitoBeforeEach = (extensionMock: object) => async () => {

--- a/test/popup.test.ts
+++ b/test/popup.test.ts
@@ -215,6 +215,48 @@ describe('openLinks (Open button)', () => {
   });
 });
 
+describe('openLinks — error handling', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    document.body.innerHTML = POPUP_HTML;
+    document.head.innerHTML = '';
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    });
+    vi.spyOn(window, 'close').mockImplementation(() => {});
+    setupBrowserMocks(['http://a.example/'], ['A']);
+    browser.tabs.create.mockResolvedValue({ id: 3 });
+    browser.tabs.update.mockResolvedValue({});
+    // groupTabs doesn't catch failures from browser.tabs.group — a
+    // nonexistent numeric tab-group id rejects with a real Chrome error.
+    browser.tabs.group.mockRejectedValue(new Error('No group with id: 12345.'));
+    await import('../src/popup/index.ts');
+    (document.querySelector('input[name="select-links"]') as HTMLInputElement).checked = true;
+    (document.getElementById('new-window-checkbox') as HTMLInputElement).checked = false;
+    (document.getElementById('tab-group-name') as HTMLInputElement).value = '12345';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('shows a friendly title with the underlying error as the subtitle', async () => {
+    document.getElementById('open-button')!.click();
+    await flushPromises();
+    expect(document.getElementById('error')!.innerText).toBe('Unable to open links');
+    expect(document.getElementById('error_sub')!.innerText).toBe('No group with id: 12345.');
+  });
+
+  test('does not close the popup', async () => {
+    document.getElementById('open-button')!.click();
+    await flushPromises();
+    expect(window.close).not.toHaveBeenCalled();
+  });
+});
+
 describe('filterRows', () => {
   const triggerFilter = (text: string) => {
     const div = document.getElementById('filter')!;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig(({ mode: _mode }) => {
     }],
     test: {
       include: ['test/**/*.test.ts'],
-      exclude: ['test/e2e.test.ts', 'test/e2e-firefox.test.ts'],
+      exclude: ['test/e2e.test.ts', 'test/e2e-firefox.test.ts', 'test/e2e-popup-behavior.test.ts'],
       setupFiles: ['./happydom.init.ts', './chrome.init.ts'],
     },
   }


### PR DESCRIPTION
## Summary
- Closes #24, closes #14
- Fix a crash + spurious-highlight bug in the popup's link filter (`highlightRegex`) when a regex match lands at the very end of the link list or exactly on a text-node boundary — the `TreeWalker` walk can run off the end of the text, and the code dereferenced the resulting `null` node
- Fix an `InvalidStateError` thrown on every keystroke in the popup — the "type anywhere to jump into the filter" handler tried to redispatch the same, already-dispatching event, which the DOM spec forbids; moving focus to the filter mid-bubble was already sufficient
- Show a friendly "Unable to open links" message instead of the raw `Error` object's default string when opening links fails
- Add ArrowUp/ArrowDown/Space keyboard navigation across the popup's link list, mirroring the existing mouse-hover highlight behavior
- Extract links from `<area href>` image maps and `formaction` buttons/inputs (`<button formaction>`, `<input type="submit"|"image" formaction>`), not just `<a href>`
- Add Playwright e2e coverage for all of the above on both Chrome (`test/e2e-popup-behavior.test.ts`, via a new `test/e2e-helpers.ts` harness) and Firefox (`test/e2e-firefox.test.ts`)

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx vitest run` — 137/137 passing
- [x] `bunx playwright test --project=chromium` — 10/10 passing
- [x] `bun run test:e2e-ff` — 8/8 passing
- [x] Manually verified all 5 fixes against real Firefox via geckodriver before porting to permanent e2e coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)